### PR TITLE
CON-3341 use order id in placed order events

### DIFF
--- a/Spec/Order.php
+++ b/Spec/Order.php
@@ -29,7 +29,7 @@ class Order
             ];
         }
         return [
-            "id" => $this->order->getQuoteId(),
+            "id" => $this->order->getId(),
             "total_price" => (float) $this->order->getGrandTotal(),
             "total_discount" => (float) $this->order->getDiscountAmount(),
             "total_tax" => (float) $this->order->getTaxAmount(),


### PR DESCRIPTION
## Summary
- fix placed order event property to use Order ID instead of Quote ID

## Testing
- `composer validate --no-check-all` *(fails: command not found)*