### PR TITLE
Send discount magnitudes as positive numbers

### DIFF
--- a/Spec/Checkout.php
+++ b/Spec/Checkout.php
@@ -31,8 +31,10 @@ class Checkout
             ];
         }
         $totals = $this->quote->getTotals();
-        $tax = (isset($totals['tax'])) ? $totals['tax']->getValue(): 0;
-        $discount = (isset($totals['discount'])) ? $totals['discount']->getValue(): 0;
+        $tax = isset($totals['tax']) ? (float) $totals['tax']->getValue() : 0.0;
+        // Magento stores the discount total as a negative value (e.g. -10.00 for $10 off).
+        // Converge expects the magnitude as a positive number.
+        $discount = isset($totals['discount']) ? abs((float) $totals['discount']->getValue()) : 0.0;
         return [
             "id" => $this->quote->getId(),
             "total_price" => (float) $this->quote->getGrandTotal(),

--- a/Spec/Order.php
+++ b/Spec/Order.php
@@ -42,7 +42,9 @@ class Order
         return [
             "id" => $this->getOrderId(),
             "total_price" => (float) $this->order->getGrandTotal(),
-            "total_discount" => (float) $this->order->getDiscountAmount(),
+            // Magento stores discount_amount as a negative value (e.g. -10.00 for $10 off).
+            // Converge expects the magnitude as a positive number.
+            "total_discount" => abs((float) $this->order->getDiscountAmount()),
             "total_tax" => (float) $this->order->getTaxAmount(),
             "currency" => $this->currency,
             "items" => $items,


### PR DESCRIPTION
## Summary

Magento stores `discount_amount` as a negative value (e.g. `-4.90` for a
$4.90 coupon discount). The Converge module was forwarding that raw
negative value as `total_discount` in `Started Checkout` and `Placed
Order` events, but Converge expects the magnitude as a positive number.

Wrapping both spec outputs in `abs()` fixes it.

- `Spec/Order.php:45` — used by `Placed Order` events
- `Spec/Checkout.php:35` — used by `Started Checkout` events

## Test plan

Validated end-to-end against a real Magento order placed with the
sample-data `H20` coupon (70% off Affirm Water Bottle):

- Magento raw `order->getDiscountAmount()`: `-4.9`
- Converge `Placed Order` payload `total_discount`: **`4.9`** ✅

Also ran a differential PHP test against the parent commit (pre-fix)
and HEAD (post-fix):
- Pre-fix: `-25.0` / `-15.0` — FAIL
- Post-fix: `25.0` / `15.0` — PASS
- No-discount edge case stays at `0.0` in both — no regression

Full QA report (not committed) at `.gstack/qa-reports/qa-report-discount-fix-2026-05-14.md`.

## Out of scope — separate finding for follow-up

While validating, I found that `Started Checkout` events under-report
discount: `Spec/Checkout.php` reads from
`$quote->getTotals()['discount']` but at checkout-render time the totals
collection doesn't surface a `discount` key (only `subtotal`, `shipping`,
`tax`, `grand_total`). So `total_discount` is emitted as `0` even with a
coupon applied. The `abs()` fix in this PR is correct for whatever value
does come through; a follow-up should change the source to read
`$quote->getShippingAddress()->getDiscountAmount()` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)