### PR TITLE
Read checkout discount from the quote address

### DIFF
--- a/Spec/Checkout.php
+++ b/Spec/Checkout.php
@@ -31,8 +31,15 @@ class Checkout
             ];
         }
         $totals = $this->quote->getTotals();
-        $tax = (isset($totals['tax'])) ? $totals['tax']->getValue(): 0;
-        $discount = (isset($totals['discount'])) ? $totals['discount']->getValue(): 0;
+        $tax = isset($totals['tax']) ? (float) $totals['tax']->getValue() : 0.0;
+        // Discount lives on the quote address, not on $quote->getTotals() (the
+        // 'discount' totals key is not populated by the default totals collector).
+        // Magento stores it as a negative value (e.g. -10.00); Converge expects the
+        // magnitude as a positive number.
+        $address = $this->quote->isVirtual()
+            ? $this->quote->getBillingAddress()
+            : $this->quote->getShippingAddress();
+        $discount = $address ? abs((float) $address->getDiscountAmount()) : 0.0;
         return [
             "id" => $this->quote->getId(),
             "total_price" => (float) $this->quote->getGrandTotal(),

--- a/Spec/Checkout.php
+++ b/Spec/Checkout.php
@@ -32,10 +32,11 @@ class Checkout
         }
         $totals = $this->quote->getTotals();
         $tax = isset($totals['tax']) ? (float) $totals['tax']->getValue() : 0.0;
-        // Discount lives on the quote address, not on $quote->getTotals() (the
-        // 'discount' totals key is not populated by the default totals collector).
-        // Magento stores it as a negative value (e.g. -10.00); Converge expects the
-        // magnitude as a positive number.
+        // Discount is collected on the quote address ($address->getTotals()
+        // has a 'discount' key), but it is NOT aggregated up to the quote-level
+        // $quote->getTotals(), so reading $totals['discount'] there always misses.
+        // Magento stores the amount as negative (e.g. -10.00); Converge expects
+        // the magnitude as a positive number.
         $address = $this->quote->isVirtual()
             ? $this->quote->getBillingAddress()
             : $this->quote->getShippingAddress();


### PR DESCRIPTION
## Summary

- The `Started Checkout` event was always reporting `total_discount: 0` even when the cart had a working coupon applied. `$quote->getTotals()` does not contain a `discount` key in standard installs, so `isset($totals['discount'])` was always false.
- Read the discount from `$quote->getShippingAddress()->getDiscountAmount()` (or the billing address for virtual carts), and wrap it in `abs()` so the magnitude is positive, matching `Spec\Order`.

This is a follow-up to #8 (`Send discount magnitudes as positive numbers`), which correctly fixed `Spec\Order` but left `Spec\Checkout` unchanged in a way that masked the same bug.

## Test plan

- [x] Verified `Spec\Checkout::get()` returns `total_discount: 3.4` for quote #12 ($34 cart) with 10% off coupon applied (Magento: `discount_amount=-3.4, grand_total=30.6`).
- [x] Verified `total_discount: 0` when no coupon is applied.
- [x] Confirmed no new entries in `exception.log`, `system.log`, or `debug.log` after exercising the patched path.
- [ ] Confirm the live `Started Checkout` event in Converge shows the positive discount amount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)