### PR TITLE
Send total_shipping in Placed Order and Checkout specs

### DIFF
--- a/Spec/Checkout.php
+++ b/Spec/Checkout.php
@@ -41,11 +41,17 @@ class Checkout
             ? $this->quote->getBillingAddress()
             : $this->quote->getShippingAddress();
         $discount = $address ? abs((float) $address->getDiscountAmount()) : 0.0;
+        // Virtual carts have no shipping; non-virtual carts carry the
+        // shipping amount on the shipping address (not the quote totals).
+        $shipping = ($address && !$this->quote->isVirtual())
+            ? (float) $address->getShippingAmount()
+            : 0.0;
         return [
             "id" => $this->quote->getId(),
             "total_price" => (float) $this->quote->getGrandTotal(),
             "total_discount" => $discount,
             "total_tax" => $tax,
+            "total_shipping" => $shipping,
             "currency" => $this->currency,
             "items" => $items,
         ];

--- a/Spec/Order.php
+++ b/Spec/Order.php
@@ -44,6 +44,7 @@ class Order
             "total_price" => (float) $this->order->getGrandTotal(),
             "total_discount" => (float) $this->order->getDiscountAmount(),
             "total_tax" => (float) $this->order->getTaxAmount(),
+            "total_shipping" => (float) $this->order->getShippingAmount(),
             "currency" => $this->currency,
             "items" => $items,
         ];


### PR DESCRIPTION
## Summary
- Add `total_shipping` to both `Spec\Order` and `Spec\Checkout` so Converge can attribute shipping revenue alongside `total_price`, `total_discount`, and `total_tax`.
- `Spec\Order`: reads `\$order->getShippingAmount()` (excluding tax, mirroring how `getTaxAmount` / `getDiscountAmount` are emitted).
- `Spec\Checkout`: reads shipping from the shipping address (Magento doesn't aggregate it onto `\$quote->getTotals()`); defaults to 0 for virtual carts and missing addresses.

## Test plan
- [x] One-off PHP script: `Spec\Order::get()` on the latest placed order in the dev stack returns `total_shipping: 5` (matches `\$order->getShippingAmount()`).
- [x] One-off PHP script: built a live guest quote (Joust Duffle Bag + Texas address + `flatrate_flatrate` + `checkmo`), confirmed `Spec\Checkout::get()` returns `total_shipping: 5`, then submitted via `CartManagementInterface::placeOrder` and confirmed `Spec\Order::get()` on the resulting order also returns `total_shipping: 5`.
- [x] `var/log/exception.log` and `var/log/system.log` contain no Converge-related errors during the test runs (only the unrelated dev-container sendmail failure).
- [ ] Verify in production / staging that downstream Converge `Started Checkout` and `Placed Order` events now carry `total_shipping`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)