### PR TITLE
Track product URL and image URL on tracking events (CON-3370)

### DIFF
--- a/Block/Checkout.php
+++ b/Block/Checkout.php
@@ -5,21 +5,28 @@ use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Checkout\Model\Session;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Catalog\Api\ProductRepositoryInterface;
 use Converge\Converge\Spec\Checkout as CheckoutSpec;
 
 class Checkout extends Template
 {
     protected $checkoutSession;
     protected $currency;
+    protected $baseMediaUrl;
+    protected $productRepository;
 
     public function __construct(
         Context $context,
         Session $checkoutSession,
         StoreManagerInterface $storeConfig,
+        ProductRepositoryInterface $productRepository,
         array $data = []
     ) {
         $this->checkoutSession = $checkoutSession;
+        $this->productRepository = $productRepository;
         $this->currency = $storeConfig->getStore()->getCurrentCurrencyCode();
+        $this->baseMediaUrl = $storeConfig->getStore()->getBaseUrl(UrlInterface::URL_TYPE_MEDIA);
         parent::__construct($context, $data);
     }
 
@@ -27,7 +34,9 @@ class Checkout extends Template
     {
         return (new CheckoutSpec(
             $this->checkoutSession->getQuote(),
-            $this->currency
+            $this->currency,
+            $this->productRepository,
+            $this->baseMediaUrl
         ))->get();
     }
 }

--- a/Block/Order.php
+++ b/Block/Order.php
@@ -5,7 +5,9 @@ use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Checkout\Model\Session;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\UrlInterface;
 use Converge\Converge\Spec\Order as OrderSpec;
+use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -15,19 +17,24 @@ class Order extends Template
     private $checkoutSession;
     private $store;
     private $currency;
+    private $baseMediaUrl;
     private $scopeConfig;
+    private $productRepository;
 
     public function __construct(
         Context $context,
         Session $checkoutSession,
         StoreManagerInterface $storeConfig,
         ScopeConfigInterface $scopeConfig,
+        ProductRepositoryInterface $productRepository,
         array $data = []
     ) {
         $this->store = $storeConfig->getStore();
         $this->checkoutSession = $checkoutSession;
         $this->scopeConfig = $scopeConfig;
+        $this->productRepository = $productRepository;
         $this->currency = $this->store->getCurrentCurrencyCode();
+        $this->baseMediaUrl = $this->store->getBaseUrl(UrlInterface::URL_TYPE_MEDIA);
         parent::__construct($context, $data);
     }
 
@@ -54,7 +61,9 @@ class Order extends Template
         return new OrderSpec(
             $this->checkoutSession->getLastRealOrder(),
             $this->getOrderDedupMethod(),
-            $this->currency
+            $this->currency,
+            $this->productRepository,
+            $this->baseMediaUrl
         );
     }
 

--- a/Block/Product.php
+++ b/Block/Product.php
@@ -3,6 +3,7 @@ namespace Converge\Converge\Block;
 
 use Converge\Converge\Spec\Product as ProductSpec;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\Registry;
 
@@ -18,12 +19,13 @@ class Product extends Template
     ) {
         $this->registry = $registry;
         $this->currency = $storeConfig->getStore()->getCurrentCurrencyCode();
+        $this->baseMediaUrl = $storeConfig->getStore()->getBaseUrl(UrlInterface::URL_TYPE_MEDIA);
         parent::__construct($context, $data);
     }
 
     public function getCurrentProduct()
     {
         $product = $this->registry->registry('current_product');
-        return (new ProductSpec($product, $this->currency))->get();
+        return (new ProductSpec($product, $this->currency, $this->baseMediaUrl))->get();
     }
 }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,8 +46,9 @@
 ### Setting up Magento 2 for local development
 ```bash
 cd dev
-cp .env.example .env             # fill in Marketplace keys
-docker compose up -d --wait
+cp .env.example .env
+$EDITOR .env                       # fill in MAGENTO_PUBLIC_KEY / PRIVATE_KEY
+docker compose up -d --wait        # ~10 min: composer install + setup:install
 ```
 Brings up a full Magento stack (Nginx, PHP-FPM, MariaDB, OpenSearch, Redis)
 with this repo bind-mounted as `app/code/Converge/Converge`. The phpfpm

--- a/Observer/AddedToCartObserver.php
+++ b/Observer/AddedToCartObserver.php
@@ -6,12 +6,14 @@ use Converge\Converge\Spec\LineItem;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\UrlInterface;
 use Converge\Converge\SessionDataProvider\CheckoutSessionDataProvider;
 
 class AddedToCartObserver implements ObserverInterface
 {
     private $checkoutSessionDataProvider;
     private $currency;
+    private $baseMediaUrl;
     protected $logger;
 
     public function __construct(
@@ -21,6 +23,7 @@ class AddedToCartObserver implements ObserverInterface
     ) {
         $this->checkoutSessionDataProvider = $checkoutSessionDataProvider;
         $this->currency = $storeConfig->getStore()->getCurrentCurrencyCode();
+        $this->baseMediaUrl = $storeConfig->getStore()->getBaseUrl(UrlInterface::URL_TYPE_MEDIA);
         $this->logger = $logger;
     }
 
@@ -34,7 +37,7 @@ class AddedToCartObserver implements ObserverInterface
                 'method' => 'track',
                 'eventID' => uniqid('', true),
                 'eventName' => 'Added To Cart',
-                'properties' => (new LineItem($product, $this->currency, $quantity))->get(),
+                'properties' => (new LineItem($product, $this->currency, $quantity, $this->baseMediaUrl))->get(),
             ]
         );
     }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Get Started
 ### Installation
 - `composer config repositories.repo-name vcs https://github.com/run-converge/converge-magento2` 
-- `composer require run-converge/converge-magento2:0.1.8`
+- `composer require run-converge/converge-magento2:0.2.0`
 - `bin/magento module:enable Converge_Converge`
 - `bin/magento setup:upgrade`
 - `bin/magento setup:static-content:deploy`

--- a/Spec/Checkout.php
+++ b/Spec/Checkout.php
@@ -2,26 +2,35 @@
 
 namespace Converge\Converge\Spec;
 
+use Converge\Converge\Spec\Product;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Model\Quote;
 
 class Checkout
 {
     private $quote;
     private $currency;
+    private $productRepository;
+    private $baseMediaUrl;
 
     public function __construct(
         Quote $quote,
-        string $currency
+        string $currency,
+        ProductRepositoryInterface $productRepository,
+        string $baseMediaUrl = ''
     ) {
         $this->quote = $quote;
         $this->currency = $currency;
+        $this->productRepository = $productRepository;
+        $this->baseMediaUrl = $baseMediaUrl;
     }
 
     public function get(): array
     {
         $items = [];
         foreach ($this->quote->getAllVisibleItems() as $item) {
-            $items[] = [
+            $lineItem = [
                 "product_id" => $item->getProductId(),
                 "name" => $item->getName(),
                 "sku" => $item->getSku(),
@@ -29,6 +38,15 @@ class Checkout
                 "quantity" => $item->getQty(),
                 "currency" => $this->currency
             ];
+            $product = $this->loadProduct((int) $item->getProductId());
+            if ($product !== null) {
+                $lineItem["url"] = $product->getProductUrl();
+                $imageUrl = Product::imageUrl($product, $this->baseMediaUrl);
+                if ($imageUrl !== null) {
+                    $lineItem["image_url"] = $imageUrl;
+                }
+            }
+            $items[] = $lineItem;
         }
         $totals = $this->quote->getTotals();
         $tax = isset($totals['tax']) ? (float) $totals['tax']->getValue() : 0.0;
@@ -55,5 +73,19 @@ class Checkout
             "currency" => $this->currency,
             "items" => $items,
         ];
+    }
+
+    /**
+     * Load the full product for a quote item so its storefront URL and image
+     * attributes are populated. Quote items may only carry a lightweight
+     * product, and the product may no longer exist. Returns null on failure.
+     */
+    private function loadProduct(int $productId)
+    {
+        try {
+            return $this->productRepository->getById($productId);
+        } catch (NoSuchEntityException $e) {
+            return null;
+        }
     }
 }

--- a/Spec/LineItem.php
+++ b/Spec/LineItem.php
@@ -14,9 +14,10 @@ class LineItem extends Product
     public function __construct(
         ProductInterface $product,
         string $currency,
-        int $quantity
+        int $quantity,
+        string $baseMediaUrl = ''
     ) {
-        parent::__construct($product, $currency);
+        parent::__construct($product, $currency, $baseMediaUrl);
         $this->quantity = $quantity;
     }
 

--- a/Spec/Order.php
+++ b/Spec/Order.php
@@ -2,23 +2,30 @@
 
 namespace Converge\Converge\Spec;
 
-use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Store\Model\ScopeInterface;
+use Converge\Converge\Spec\Product;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
 
 class Order
 {
     private $order;
     private $currency;
     private $orderDedupMethod;
+    private $productRepository;
+    private $baseMediaUrl;
 
     public function __construct(
         \Magento\Sales\Model\Order $order,
         string $orderDedupMethod,
-        string $currency
+        string $currency,
+        ProductRepositoryInterface $productRepository,
+        string $baseMediaUrl = ''
     ) {
         $this->order = $order;
         $this->currency = $currency;
         $this->orderDedupMethod = $orderDedupMethod;
+        $this->productRepository = $productRepository;
+        $this->baseMediaUrl = $baseMediaUrl;
     }
 
     private function getOrderId(): string
@@ -26,11 +33,25 @@ class Order
         return $this->orderDedupMethod === 'order_id' ? $this->order->getRealOrderId() : $this->order->getQuoteId();
     }
 
+    /**
+     * Load the full product for a line item so its storefront URL and image
+     * attributes are populated. Order items may only carry a lightweight
+     * product, and the product may no longer exist. Returns null on failure.
+     */
+    private function loadProduct(int $productId)
+    {
+        try {
+            return $this->productRepository->getById($productId);
+        } catch (NoSuchEntityException $e) {
+            return null;
+        }
+    }
+
     public function get(): array
     {
         $items = [];
         foreach ($this->order->getAllVisibleItems() as $item) {
-            $items[] = [
+            $lineItem = [
                 "product_id" => $item->getProductId(),
                 "name" => $item->getName(),
                 "sku" => $item->getSku(),
@@ -38,6 +59,15 @@ class Order
                 "quantity" => (float) $item->getQtyOrdered(),
                 "currency" => $this->currency
             ];
+            $product = $this->loadProduct((int) $item->getProductId());
+            if ($product !== null) {
+                $lineItem["url"] = $product->getProductUrl();
+                $imageUrl = Product::imageUrl($product, $this->baseMediaUrl);
+                if ($imageUrl !== null) {
+                    $lineItem["image_url"] = $imageUrl;
+                }
+            }
+            $items[] = $lineItem;
         }
         return [
             "id" => $this->getOrderId(),

--- a/Spec/Product.php
+++ b/Spec/Product.php
@@ -8,23 +8,46 @@ class Product
 {
     private $product;
     private $currency;
+    private $baseMediaUrl;
 
     public function __construct(
         ProductInterface $product,
-        string $currency
+        string $currency,
+        string $baseMediaUrl = ''
     ) {
         $this->product = $product;
         $this->currency = $currency;
+        $this->baseMediaUrl = $baseMediaUrl;
     }
 
     public function get(): array
     {
-        return [
+        $properties = [
             'product_id' => (string) $this->product->getId(),
             'name' => $this->product->getName(),
             'sku' => $this->product->getSku(),
             'price' => $this->product->getFinalPrice(),
-            'currency' => $this->currency
+            'currency' => $this->currency,
+            'url' => $this->product->getProductUrl()
         ];
+        $imageUrl = self::imageUrl($this->product, $this->baseMediaUrl);
+        if ($imageUrl !== null) {
+            $properties['image_url'] = $imageUrl;
+        }
+        return $properties;
+    }
+
+    /**
+     * Build the absolute base-image URL for a product, or null when the product
+     * has no assigned image (getImage() is empty or the "no_selection"
+     * sentinel) or no media base URL is available.
+     */
+    public static function imageUrl(ProductInterface $product, string $baseMediaUrl): ?string
+    {
+        $image = $product->getImage();
+        if (empty($image) || $image === 'no_selection' || $baseMediaUrl === '') {
+            return null;
+        }
+        return rtrim($baseMediaUrl, '/') . '/catalog/product/' . ltrim($image, '/');
     }
 }

--- a/Test/Unit/Spec/CheckoutTest.php
+++ b/Test/Unit/Spec/CheckoutTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Converge\Converge\Test\Unit\Spec;
+
+use Converge\Converge\Spec\Checkout;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Phrase;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Item as QuoteItem;
+use PHPUnit\Framework\TestCase;
+
+class CheckoutTest extends TestCase
+{
+    private function quoteItem(int $productId): QuoteItem
+    {
+        // getProductId() is a magic getter on the quote item (registered via
+        // addMethods()); the rest are declared methods (onlyMethods()).
+        $item = $this->getMockBuilder(QuoteItem::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['getProductId'])
+            ->onlyMethods(['getName', 'getSku', 'getPrice', 'getQty'])
+            ->getMock();
+        $item->method('getProductId')->willReturn($productId);
+        $item->method('getName')->willReturn('Radiant Tee');
+        $item->method('getSku')->willReturn('WS12-XS-Blue');
+        $item->method('getPrice')->willReturn(22.0);
+        $item->method('getQty')->willReturn(1.0);
+        return $item;
+    }
+
+    /**
+     * A quote with the given visible items and no totals/address wired, so
+     * discount/tax/shipping collapse to 0 and the test stays focused on items.
+     *
+     * @param QuoteItem[] $items
+     */
+    private function quote(array $items): Quote
+    {
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getAllVisibleItems')->willReturn($items);
+        $quote->method('getTotals')->willReturn([]);
+        $quote->method('isVirtual')->willReturn(false);
+        $quote->method('getShippingAddress')->willReturn(null);
+        return $quote;
+    }
+
+    public function testItemsCarryParentUrlAndImageFromRepository(): void
+    {
+        $parent = $this->createMock(CatalogProduct::class);
+        $parent->method('getProductUrl')->willReturn('http://example.com/radiant-tee.html');
+        $parent->method('getImage')->willReturn('/w/s/ws12-orange_main_2.jpg');
+
+        $repository = $this->createMock(ProductRepositoryInterface::class);
+        $repository->expects($this->once())->method('getById')->with(1556)->willReturn($parent);
+
+        $result = (new Checkout(
+            $this->quote([$this->quoteItem(1556)]),
+            'USD',
+            $repository,
+            'http://example.com/media/'
+        ))->get();
+
+        $item = $result['items'][0];
+        $this->assertSame('http://example.com/radiant-tee.html', $item['url']);
+        $this->assertSame(
+            'http://example.com/media/catalog/product/w/s/ws12-orange_main_2.jpg',
+            $item['image_url']
+        );
+        $this->assertSame('WS12-XS-Blue', $item['sku']);
+    }
+
+    public function testDeletedProductStillEmittedWithoutUrlOrImage(): void
+    {
+        $repository = $this->createMock(ProductRepositoryInterface::class);
+        $repository->method('getById')->willThrowException(new NoSuchEntityException(new Phrase('gone')));
+
+        $result = (new Checkout(
+            $this->quote([$this->quoteItem(999)]),
+            'USD',
+            $repository,
+            'http://example.com/media/'
+        ))->get();
+
+        $item = $result['items'][0];
+        $this->assertArrayNotHasKey('url', $item);
+        $this->assertArrayNotHasKey('image_url', $item);
+        $this->assertSame('WS12-XS-Blue', $item['sku']);
+    }
+}

--- a/Test/Unit/Spec/OrderTest.php
+++ b/Test/Unit/Spec/OrderTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Converge\Converge\Test\Unit\Spec;
+
+use Converge\Converge\Spec\Order;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Phrase;
+use Magento\Sales\Model\Order as SalesOrder;
+use Magento\Sales\Model\Order\Item as OrderItem;
+use PHPUnit\Framework\TestCase;
+
+class OrderTest extends TestCase
+{
+    private function orderItem(int $productId): OrderItem
+    {
+        $item = $this->createMock(OrderItem::class);
+        $item->method('getProductId')->willReturn($productId);
+        $item->method('getName')->willReturn('Radiant Tee');
+        $item->method('getSku')->willReturn('WS12-XS-Blue');
+        $item->method('getPrice')->willReturn(22.0);
+        $item->method('getQtyOrdered')->willReturn(1.0);
+        return $item;
+    }
+
+    /**
+     * @param OrderItem[] $items
+     */
+    private function order(array $items): SalesOrder
+    {
+        $order = $this->createMock(SalesOrder::class);
+        $order->method('getAllVisibleItems')->willReturn($items);
+        $order->method('getQuoteId')->willReturn('6');
+        return $order;
+    }
+
+    public function testItemsCarryParentUrlAndImageFromRepository(): void
+    {
+        // getAllVisibleItems() returns the parent line item, whose getProductId()
+        // is the parent's id; the repository load resolves url/image from it.
+        $parent = $this->createMock(CatalogProduct::class);
+        $parent->method('getProductUrl')->willReturn('http://example.com/radiant-tee.html');
+        $parent->method('getImage')->willReturn('/w/s/ws12-orange_main_2.jpg');
+
+        $repository = $this->createMock(ProductRepositoryInterface::class);
+        $repository->expects($this->once())->method('getById')->with(1556)->willReturn($parent);
+
+        $result = (new Order(
+            $this->order([$this->orderItem(1556)]),
+            'quote_id',
+            'USD',
+            $repository,
+            'http://example.com/media/'
+        ))->get();
+
+        $item = $result['items'][0];
+        $this->assertSame('http://example.com/radiant-tee.html', $item['url']);
+        $this->assertSame(
+            'http://example.com/media/catalog/product/w/s/ws12-orange_main_2.jpg',
+            $item['image_url']
+        );
+        // The variant sku comes from the line item, untouched by the url/image code.
+        $this->assertSame('WS12-XS-Blue', $item['sku']);
+    }
+
+    public function testDeletedProductStillEmittedWithoutUrlOrImage(): void
+    {
+        $repository = $this->createMock(ProductRepositoryInterface::class);
+        $repository->method('getById')->willThrowException(new NoSuchEntityException(new Phrase('gone')));
+
+        $result = (new Order(
+            $this->order([$this->orderItem(999)]),
+            'quote_id',
+            'USD',
+            $repository,
+            'http://example.com/media/'
+        ))->get();
+
+        $item = $result['items'][0];
+        $this->assertArrayNotHasKey('url', $item);
+        $this->assertArrayNotHasKey('image_url', $item);
+        // Core line-item fields are still emitted.
+        $this->assertSame('WS12-XS-Blue', $item['sku']);
+    }
+}

--- a/Test/Unit/Spec/ProductTest.php
+++ b/Test/Unit/Spec/ProductTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Converge\Converge\Test\Unit\Spec;
+
+use Converge\Converge\Spec\Product;
+use Magento\Catalog\Model\Product as CatalogProduct;
+use PHPUnit\Framework\TestCase;
+
+class ProductTest extends TestCase
+{
+    /**
+     * @param array<string,mixed> $data
+     */
+    private function product(array $data = []): CatalogProduct
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getId')->willReturn($data['id'] ?? 1);
+        $product->method('getName')->willReturn($data['name'] ?? 'Joust Duffle Bag');
+        $product->method('getSku')->willReturn($data['sku'] ?? '24-MB01');
+        $product->method('getFinalPrice')->willReturn($data['price'] ?? 34.0);
+        $product->method('getProductUrl')->willReturn($data['url'] ?? 'http://example.com/joust-duffle-bag.html');
+        $product->method('getImage')->willReturn($data['image'] ?? '/m/b/mb01-blue-0.jpg');
+        return $product;
+    }
+
+    public function testGetIncludesUrlAndImageUrl(): void
+    {
+        $result = (new Product($this->product(), 'USD', 'http://example.com/media/'))->get();
+
+        $this->assertSame('http://example.com/joust-duffle-bag.html', $result['url']);
+        $this->assertSame(
+            'http://example.com/media/catalog/product/m/b/mb01-blue-0.jpg',
+            $result['image_url']
+        );
+        // Existing fields are untouched.
+        $this->assertSame('1', $result['product_id']);
+        $this->assertSame('24-MB01', $result['sku']);
+        $this->assertSame('USD', $result['currency']);
+    }
+
+    public function testImageUrlOmittedWhenProductHasNoImage(): void
+    {
+        $result = (new Product($this->product(['image' => 'no_selection']), 'USD', 'http://example.com/media/'))->get();
+
+        // A URL is always present, but image_url is dropped rather than emitted empty.
+        $this->assertArrayHasKey('url', $result);
+        $this->assertArrayNotHasKey('image_url', $result);
+    }
+
+    /**
+     * @return array<string,array{0:?string,1:string,2:?string}>
+     */
+    public function imageUrlProvider(): array
+    {
+        return [
+            'leading slash on image' => [
+                '/m/b/mb01-blue-0.jpg',
+                'http://example.com/media/',
+                'http://example.com/media/catalog/product/m/b/mb01-blue-0.jpg',
+            ],
+            'no leading slash on image' => [
+                'm/b/mb01-blue-0.jpg',
+                'http://example.com/media/',
+                'http://example.com/media/catalog/product/m/b/mb01-blue-0.jpg',
+            ],
+            'base url without trailing slash' => [
+                '/m/b/mb01-blue-0.jpg',
+                'http://example.com/media',
+                'http://example.com/media/catalog/product/m/b/mb01-blue-0.jpg',
+            ],
+            'no_selection sentinel' => ['no_selection', 'http://example.com/media/', null],
+            'empty image' => ['', 'http://example.com/media/', null],
+            'null image' => [null, 'http://example.com/media/', null],
+            'missing media base url' => ['/m/b/mb01-blue-0.jpg', '', null],
+        ];
+    }
+
+    /**
+     * @dataProvider imageUrlProvider
+     */
+    public function testImageUrl(?string $image, string $baseMediaUrl, ?string $expected): void
+    {
+        $product = $this->createMock(CatalogProduct::class);
+        $product->method('getImage')->willReturn($image);
+
+        $this->assertSame($expected, Product::imageUrl($product, $baseMediaUrl));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "run-converge/converge-magento2",
     "description": "Converge Tracking for Magento 2",
     "type": "magento2-module",
-    "version": "0.1.8",
+    "version": "0.2.0",
     "require": {
         "php": ">=7.3 || ^8.0"
     },

--- a/dev/Justfile
+++ b/dev/Justfile
@@ -27,3 +27,7 @@ sample-data:
 # Run bin/magento <args> inside the container, e.g. `just magento cache:flush`.
 magento *args:
     {{php}} bin/magento {{args}}
+
+# Run the module's PHPUnit unit tests (pass extra args, e.g. `just test --filter ProductTest`).
+test *args:
+    {{php}} vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist app/code/Converge/Converge/Test/Unit {{args}}

--- a/dev/compose.yaml
+++ b/dev/compose.yaml
@@ -34,6 +34,29 @@ services:
   redis:
     image: redis:7-alpine
 
+  # Docker creates the phpfpm repo bind-mount's parent dirs
+  # (/var/www/html/app/code/Converge) owned by root before install.sh runs
+  # as the `app` user — which then can't create app/etc during composer
+  # install, so the whole install aborts on app/etc/vendor_path.php. This
+  # one-shot pre-creates that path in the appdata volume and hands the
+  # module-parent chain to `app` so the Magento install can populate app/.
+  # It deliberately does NOT bind-mount the repo, so the chown can't reach
+  # host files.
+  init-perms:
+    image: markoshust/magento-php:${PHP_TAG:-8.3-fpm-5}
+    user: root
+    volumes:
+      - appdata:/var/www/html
+    command:
+      - bash
+      - -c
+      - >-
+        mkdir -p /var/www/html/app/code/Converge &&
+        chown app:app
+        /var/www/html /var/www/html/app
+        /var/www/html/app/code /var/www/html/app/code/Converge
+    restart: "no"
+
   phpfpm:
     image: markoshust/magento-php:${PHP_TAG:-8.3-fpm-5}
     user: app
@@ -80,6 +103,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
+      init-perms:
+        condition: service_completed_successfully
 
   nginx:
     image: markoshust/magento-nginx:${NGINX_TAG:-1.24-0}

--- a/dev/install.sh
+++ b/dev/install.sh
@@ -76,6 +76,19 @@ fi
 echo "==> enable Converge_Converge"
 bin/magento module:enable Converge_Converge
 bin/magento config:set oauth/consumer/enable_integration_as_bearer 1
+
+# Magento 2.4 forces admin Two-Factor Auth, which emails a setup link on first
+# login. This stack has no mail server, so that send fails ("Failed to send the
+# message. Please contact the administrator") and the admin is unreachable.
+# Disable the 2FA modules so localhost admin works with just user/pass. Order
+# matters: Magento_AdminAdobeImsTwoFactorAuth depends on Magento_TwoFactorAuth,
+# so the dependent must be disabled first or the core module's disable is
+# refused. Each call is best-effort — a module may be absent on some versions,
+# or already disabled, and neither should abort the install.
+for tfa_module in Magento_AdminAdobeImsTwoFactorAuth Magento_TwoFactorAuth; do
+    bin/magento module:disable "$tfa_module" 2>/dev/null || true
+done
+
 bin/magento setup:upgrade
 bin/magento deploy:mode:set developer -s
 bin/magento cache:flush


### PR DESCRIPTION
## CON-3370 — Track Product URL and Product Image URL

Converge customers use product URL and image URL in Klaviyo flows (cart-abandonment, add-to-cart emails). The extension's tracking events didn't include these, so customers had to hand-extend their tracking — a live support blocker (PK Consumer Health, Keskisen Kello, both missing product image URLs in Klaviyo).

This adds the canonical `url` and `image_url` properties to every product payload, using the exact keys Converge's backend forwarders read (`url` → Klaviyo `URL`, `image_url` → Klaviyo `ImageURL`).

### What changed

All three payload-building sites now emit `url` + `image_url`:

- **`Spec/Product`** — `get()` adds `url` (`getProductUrl()`) and `image_url`; a static `imageUrl()` helper builds `{baseMedia}/catalog/product/{image}` and returns `null` for empty / `no_selection` images. Feeds **Viewed Product** and **Added To Cart** (via `Spec/LineItem`).
- **`Spec/Order`** / **`Spec/Checkout`** — enrich each visible line item, loading the full product via `ProductRepositoryInterface` so `url_key`/`image` are reliably populated (guarded against deleted products). Configurable/bundle items resolve to the **parent** product's storefront page, consistent with the existing line-item grouping.
- **Blocks / Observer** — pass `baseMediaUrl` (`URL_TYPE_MEDIA`) and, for Order/Checkout, the product repository — mirroring how `currency` already flows.

### Design notes

- Passed `baseMediaUrl` as a string rather than injecting the `Image` helper, keeping the specs plain `new`-able classes.
- Order/Checkout load via `ProductRepositoryInterface` (not `$item->getProduct()`) so url/image are reliably store-scoped; `NoSuchEntityException` is caught so a deleted product still emits its line item (without url/image).

### Tests

`Test/Unit/Spec/{Product,Order,Checkout}Test` — 13 tests / 28 assertions, run under the host Magento's PHPUnit (no new module dependency). They pin the exact key names and the image guard (`no_selection`/empty/null → omitted), the leading-/trailing-slash join, and the deleted-product path. Run with `cd dev && just test`.

### Verification

Verified end-to-end on a running store (sample data), with the events confirmed as **received by the Converge backend** for both a simple product (Joust Duffle Bag) and a configurable (Radiant Tee):

| Event | simple | configurable |
|---|:-:|:-:|
| Viewed Product | ✓ | ✓ |
| Added To Cart | ✓ | ✓ |
| Started Checkout | ✓ | ✓ |
| Placed Order | ✓ | ✓ |

For configurables, `url`/`image_url` resolve to the parent's storefront page + image while `sku` carries the selected variant. `phpcs` (Magento2 standard): 0 errors.

### Also included — dev-stack fixes

Bundled here because they were needed to stand up the harness for verification (each its own commit):

- **`dev: fix first-boot permission failure`** — the repo bind-mount's parent (`app/`) was created as root before `install.sh` ran as `app`, so `composer install` couldn't write `app/etc` and the install aborted on `app/etc/vendor_path.php`. Adds a one-shot `init-perms` service that hands the module-parent chain to `app` before phpfpm boots.
- **`dev: disable admin 2FA`** — Magento 2.4 mandates admin 2FA and emails a setup link; the stack has no mail server, so login was impossible. Disables the 2FA modules during install (dependent module first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
